### PR TITLE
(htcondor) set new parameters

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,7 +6,16 @@
 
 ### Classes
 
+#### Public Classes
+
 * [`htcondor`](#htcondor): Installs htcondor as scheduler
+
+#### Private Classes
+
+* `htcondor::config`
+* `htcondor::install`
+* `htcondor::repo`
+* `htcondor::service`
 
 ## Classes
 

--- a/examples/basic.pp
+++ b/examples/basic.pp
@@ -1,6 +1,18 @@
 require epel
 
 Yumrepo['epel'] -> Class['htcondor']
+Class['yum'] -> Class['htcondor']
+
+class { 'yum':
+  managed_repos => [
+    'crb',
+  ],
+  repos => {
+    'crb' => {
+      'enabled' => true,
+    },
+  },
+}
 
 class { 'htcondor':
   htcondor_version  => '23.0',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,69 @@
+# @api private
+class htcondor::config {
+  assert_private()
+
+  $htcondor_host = $htcondor::htcondor_host
+  $htcondor_pswfile = $htcondor::htcondor_pswfile
+  $htcondor_password = $htcondor::htcondor_password
+  $config_path = '/etc/condor/config.d'
+
+  file { '/etc/condor/condor_config.local':
+    ensure  => file,
+    content => @(EOF)
+      ALLOW_WRITE = 10.*, 139.229.*
+      ALLOW_NEGOTIATOR = 10.*, 139.229.*
+      ALLOW_DAEMON = 10.*, 139.229.*
+
+      use SECURITY: Strong
+      SEC_DEFAULT_AUTHENTICATION_METHODS = FS, PASSWORD
+      SEC_READ_AUTHENTICATION_METHODS = $(SEC_DEFAULT_AUTHENTICATION_METHODS),ANONYMOUS
+      SEC_CLIENT_AUTHENTICATION_METHODS = $(SEC_DEFAULT_AUTHENTICATION_METHODS),ANONYMOUS
+
+      DAEMON_LIST = $(DAEMON_LIST), SHARED_PORT
+      SHARED_PORT_ARGS = -p 9618
+      USE_SHARED_PORT = TRUE
+
+      UPDATE_COLLECTOR_WITH_TCP = TRUE
+
+      UID_DOMAIN = lsst.org
+      FILESYSTEM_DOMAIN  = lsst.org
+      SOFT_UID_DOMAIN = TRUE
+      | EOF
+    ,
+  }
+
+  file { "${config_path}/schedd":
+    ensure  => file,
+    content => @(CONTENT)
+      DAEMON_LIST = MASTER, SCHEDD
+      HISTORY_CONTAINS_JOB_ENVIRONMENT = False
+      | CONTENT
+    ,
+  }
+
+  file { "${config_path}/dagman":
+    ensure  => file,
+    content => 'DAGMAN_MANAGER_JOB_APPEND_GETENV = True',
+  }
+
+  if $htcondor_pswfile and $htcondor_password {
+    file { regsubst($htcondor_pswfile, '^(.*/).*$', '\1'):
+      ensure  => directory,
+    }
+
+    file { $htcondor_pswfile:
+      ensure  => file,
+      mode    => '0600',
+      content => $htcondor_password,
+    }
+
+    file { "${config_path}/docker":
+      ensure  => file,
+      content => @("EOF")
+        CONDOR_HOST = ${htcondor_host}
+        SEC_PASSWORD_FILE = ${htcondor_pswfile}
+        | EOF
+      ,
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,77 +21,13 @@ class htcondor (
   Optional[String[1]] $htcondor_password = undef,
 
 ) {
-  yumrepo { 'condor':
-    descr               => 'htcondor repo',
-    baseurl             => "https://research.cs.wisc.edu/htcondor/repo/${htcondor_version}/el9/\$basearch/release/",
-    skip_if_unavailable => 'true',
-    gpgcheck            => '1',
-    gpgkey              => "https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${htcondor_version}-Key",
-    enabled             => '1',
-    target              => '/etc/yum.repos.d/htcondor.repo',
-  }
-  -> package { 'condor':
-    ensure => 'installed',
-  }
+  contain htcondor::repo
+  contain htcondor::install
+  contain htcondor::config
+  contain htcondor::service
 
-  file { '/etc/condor/condor_config.local':
-    ensure  => file,
-    content => @(EOF)
-      ALLOW_WRITE = 10.*, 139.229.*
-      ALLOW_NEGOTIATOR = 10.*, 139.229.*
-      ALLOW_DAEMON = 10.*, 139.229.*
-
-      use SECURITY: Strong
-      SEC_DEFAULT_AUTHENTICATION_METHODS = FS, PASSWORD
-      SEC_READ_AUTHENTICATION_METHODS = $(SEC_DEFAULT_AUTHENTICATION_METHODS),ANONYMOUS
-      SEC_CLIENT_AUTHENTICATION_METHODS = $(SEC_DEFAULT_AUTHENTICATION_METHODS),ANONYMOUS
-
-      DAEMON_LIST = $(DAEMON_LIST), SHARED_PORT
-      SHARED_PORT_ARGS = -p 9618
-      USE_SHARED_PORT = TRUE
-
-      UPDATE_COLLECTOR_WITH_TCP = TRUE
-
-      UID_DOMAIN = lsst.org
-      FILESYSTEM_DOMAIN  = lsst.org
-      SOFT_UID_DOMAIN = TRUE
-      | EOF
-    ,
-    require => Yumrepo['condor'],
-  }
-
-  file { '/etc/condor/config.d/schedd':
-    ensure  => file,
-    content => 'DAEMON_LIST = MASTER, SCHEDD',
-    require => Yumrepo['condor'],
-  }
-
-  if $htcondor_pswfile and $htcondor_password {
-    file { regsubst($htcondor_pswfile, '^(.*/).*$', '\1'):
-      ensure  => directory,
-      require => Yumrepo['condor'],
-    }
-
-    file { $htcondor_pswfile:
-      ensure  => file,
-      mode    => '0600',
-      content => $htcondor_password,
-      require => Yumrepo['condor'],
-    }
-
-    file { '/etc/condor/config.d/docker':
-      ensure  => file,
-      content => @("EOF")
-        CONDOR_HOST = ${htcondor_host}
-        SEC_PASSWORD_FILE = ${htcondor_pswfile}
-        | EOF
-      ,
-      require => Yumrepo['condor'],
-    }
-  }
-  service { 'condor':
-    ensure  => 'running',
-    enable  => true,
-    require => Yumrepo['condor'],
-  }
+  Class['htcondor::repo']
+  -> Class['htcondor::install']
+  -> Class['htcondor::config']
+  ~> Class['htcondor::service']
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,6 @@
+# @api private
+class htcondor::install {
+  assert_private()
+
+  ensure_packages(['condor'], { ensure => 'present' })
+}

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,0 +1,16 @@
+# @api private
+class htcondor::repo {
+  assert_private()
+
+  $htcondor_version = $htcondor::htcondor_version
+
+  yumrepo { 'condor':
+    descr               => 'htcondor repo',
+    baseurl             => "https://research.cs.wisc.edu/htcondor/repo/${htcondor_version}/el9/\$basearch/release/",
+    skip_if_unavailable => 'true',
+    gpgcheck            => '1',
+    gpgkey              => "https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${htcondor_version}-Key",
+    enabled             => '1',
+    target              => '/etc/yum.repos.d/htcondor.repo',
+  }
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,8 @@
+# @api private
+class htcondor::service {
+  assert_private()
+  service { 'condor':
+    ensure => 'running',
+    enable => true,
+  }
+}

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -39,9 +39,20 @@ describe 'htcondor class' do
       end
     end
 
+    describe file('/etc/condor/config.d/dagman') do
+      it { is_expected.to be_file }
+      its(:content) { is_expected.to match %r{^DAGMAN_MANAGER_JOB_APPEND_GETENV = True} }
+    end
+
     describe file('/etc/condor/config.d/schedd') do
       it { is_expected.to be_file }
-      its(:content) { is_expected.to match %r{^DAEMON_LIST = MASTER, SCHEDD} }
+
+      its(:content) do
+        is_expected.to match <<~CONTENT
+          DAEMON_LIST = MASTER, SCHEDD
+          HISTORY_CONTAINS_JOB_ENVIRONMENT = False
+        CONTENT
+      end
     end
 
     describe file('/etc/condor/config.d/docker') do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -17,15 +17,15 @@ describe 'htcondor' do
 
     it { is_expected.to contain_yumrepo('condor') }
 
-    it do
-      is_expected.to contain_package('condor').that_requires('Yumrepo[condor]')
-    end
+    it { is_expected.to contain_package('condor').that_requires('Yumrepo[condor]') }
 
-    it { is_expected.to contain_file('/etc/condor/condor_config.local') }
+    it { is_expected.to contain_file('/etc/condor/condor_config.local').that_requires('Package[condor]') }
 
-    it { is_expected.to contain_file('/etc/condor/config.d/docker') }
+    it { is_expected.to contain_file('/etc/condor/config.d/docker').that_requires('Package[condor]') }
 
-    it { is_expected.to contain_file('/etc/condor/config.d/schedd').with_content(%r{^DAEMON_LIST = MASTER, SCHEDD}) }
+    it { is_expected.to contain_file('/etc/condor/config.d/schedd') }
+
+    it { is_expected.to contain_file('/etc/condor/config.d/dagman') }
 
     it do
       is_expected.to contain_service('condor').with(

--- a/spec/support/acceptance/setup.rb
+++ b/spec/support/acceptance/setup.rb
@@ -2,4 +2,5 @@
 
 configure_beaker(modules: :metadata) do |host|
   install_puppet_module_via_pmt_on(host, 'puppet/epel')
+  install_puppet_module_via_pmt_on(host, 'puppet/yum')
 end


### PR DESCRIPTION
it was requested that the Schedulers have this 2 settings.
```DAGMAN_MANAGER_JOB_APPEND_GETENV = True```
```HISTORY_CONTAINS_JOB_ENVIRONMENT = False```
one is set at the schedd config and the other has its own config file `dagman`